### PR TITLE
Update the reference to k6 docs to point to grafana.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # k6
 
-Enhances Visual Studio Code with the ability to run k6 tests both on your local machine and in the k6 cloud.
+Enhances Visual Studio Code with the ability to run k6 tests both on your local machine and in the Grafana Cloud.
 
 ![VS Code k6 Commands](vscode-commands.png)
 
 ### For more information
 
 - [k6.io](https://k6.io)
-- [k6.io - Documentation](https://k6.io/docs/)
+- [Grafana k6 Documentation](https://grafana.com/docs/k6)
 
 **Enjoy!**


### PR DESCRIPTION
k6 documentation is now part of [Grafana Docs](https://grafana.com/docs) and k6 cloud has been replaced with Grafana Cloud.