### PR TITLE
[codex] ci: add Open VSX publish workflow

### DIFF
--- a/.github/workflows/publish-open-vsx.yml
+++ b/.github/workflows/publish-open-vsx.yml
@@ -1,0 +1,45 @@
+name: Publish Open VSX Extension
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: npm ci
+      - run: npm run compile
+      - run: npm run lint
+
+  publish_open_vsx:
+    needs: validate
+    runs-on: ubuntu-latest
+    # These permissions are needed to assume roles from GitHub's OIDC.
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - run: npm ci
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@a37de51f3d713a30a9e4b21bcdfbd38170020593 # get-vault-secrets/v1.3.0
+        with:
+          # Secrets are stored in Vault under ci/repo/grafana/k6-vscode-extension/<path>.
+          repo_secrets: |
+            OPEN_VSX_TOKEN=openvsx:token
+      - name: Publish to Open VSX
+        uses: HaaLeo/publish-vscode-extension@ca5561daa085dee804bf9f37fe0165785a9b14db # v2.0.0
+        with:
+          pat: ${{ env.OPEN_VSX_TOKEN }}
+          registryUrl: https://open-vsx.org

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Enhances Visual Studio Code with the ability to run k6 tests both on your local 
 
 ![VS Code k6 Commands](vscode-commands.png)
 
+## Install
+
+Install the extension from the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=k6.k6) or [Open VSX](https://open-vsx.org/extension/k6/k6).
+
 ### For more information
 
 - [k6.io](https://k6.io)


### PR DESCRIPTION
Closes #17.

## Summary

This PR adds a GitHub Actions workflow to publish the extension to Open VSX.

It follows the same general approach of publishing on `tag` push events that's used in other Grafana VS Code extension repos:

- [`grafana/vscode-jsonnet` publish workflow](https://github.com/grafana/vscode-jsonnet/blob/3870b0259b75115898e3c809f4e2c71f4acfcaf9/.github/workflows/publish.yml)
- [`grafana/vscode-alloy` publish workflow](https://github.com/grafana/vscode-alloy/blob/9576ca1e0493b15a92e0277c327a2456d7a6e2f1/.github/workflows/publish.yml)

Changes in this PR:

- add `.github/workflows/publish-open-vsx.yml`
- run validation (`npm ci`, `npm run compile`, `npm run lint`) before publish
- publish to Open VSX on `v*` tag pushes and `workflow_dispatch`
- fetch the Open VSX token via `grafana/shared-workflows/actions/get-vault-secrets`
- update `README.md` to include both VS Marketplace and Open VSX install links

## Maintainer setup before first publish

Before this workflow can publish successfully, maintainers will need to connect it to Grafana's existing Open VSX publishing setup.

1. Create or claim the `k6` namespace in Open VSX.
   The namespace comes from the extension [`publisher`](https://github.com/esmail/k6-vscode-extension/blob/afe60f5/package.json#L4); Open VSX documents that mapping here:
   - [Publishing Extensions: 4. Create the namespace](https://github.com/eclipse-openvsx/openvsx/wiki/Publishing-Extensions#4-create-the-namespace)
   - [Namespace Access: Namespaces in Open VSX](https://github.com/eclipse-openvsx/openvsx/wiki/Namespace-Access#namespaces-in-open-vsx)

2. Claim ownership of the `k6` namespace so published versions are verified.
   Relevant docs:
   - [Namespace Access: How to Claim a Namespace](https://github.com/eclipse-openvsx/openvsx/wiki/Namespace-Access#how-to-claim-a-namespace)

3. Add Grafana's existing Open VSX CI/service account as a **Contributor** to the `k6` namespace.
   Relevant docs:
   - [Namespace Access: How to Manage Namespace Members](https://github.com/eclipse-openvsx/openvsx/wiki/Namespace-Access#how-to-manage-namespace-members)

4. Reuse the existing token for that Grafana Open VSX CI/service account if possible. If that token does not already work for the `k6` namespace, mint a new PAT for the same account after it has namespace access.
   Relevant docs:
   - [Publishing Extensions: 3. Create an access token](https://github.com/eclipse-openvsx/openvsx/wiki/Publishing-Extensions#3-create-an-access-token)

5. If step 4 results in a new token, or the currently configured token needs to be replaced, update the repo-specific Vault entry consumed by `grafana/shared-workflows`, following the same pattern as:
   - [`grafana/vscode-jsonnet` publish workflow](https://github.com/grafana/vscode-jsonnet/blob/3870b0259b75115898e3c809f4e2c71f4acfcaf9/.github/workflows/publish.yml)
   - [`grafana/vscode-alloy` publish workflow](https://github.com/grafana/vscode-alloy/blob/9576ca1e0493b15a92e0277c327a2456d7a6e2f1/.github/workflows/publish.yml)

6. Trigger the workflow manually once, or publish the next `v*` tag, to create the first Open VSX release.

Notes:

- `npm run lint` still reports one existing warning in `src/commands/run/index.ts` for the `K6_CLOUD_TOKEN` property name.
- No runtime extension behavior was changed in this PR.

<details>
<summary>Draft assumptions / choices in this PR</summary>

### Why keep `publisher: "k6"` for now?

This PR keeps the current publisher unchanged because it avoids mixing Open VSX enablement with an extension identity change.

For reference, the Grafana examples linked above both publish under the `Grafana` namespace:
- [`vscode-jsonnet` publisher](https://github.com/grafana/vscode-jsonnet/blob/3870b0259b75115898e3c809f4e2c71f4acfcaf9/package.json#L7)
- [`vscode-alloy` publisher](https://github.com/grafana/vscode-alloy/blob/9576ca1e0493b15a92e0277c327a2456d7a6e2f1/package.json#L8)

If maintainers want this extension to move under `Grafana` later, that can still be done, but I treated it as a separate follow-up because it changes registry identity and publishing setup.

### Why publish only to Open VSX here?

Issue #17 is specifically about Open VSX.

Also, from what I was able to verify while preparing this PR, I could not determine how VS Marketplace publishing is currently managed, so I did not want to risk adding something duplicative or conflicting.

</details>
